### PR TITLE
Fix issue where ManageDSAit control sent

### DIFF
--- a/control.go
+++ b/control.go
@@ -5,6 +5,7 @@
 package ldap
 
 import (
+	"strings"
 	"fmt"
 	"github.com/nmcclain/asn1-ber"
 )

--- a/control.go
+++ b/control.go
@@ -40,7 +40,7 @@ func (c *ControlString) Encode() *ber.Packet {
 	if c.Criticality {
 		packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Criticality, "Criticality"))
 	}
-	if string.TrimSpace(c.ControlValue) != "" {
+	if strings.TrimSpace(c.ControlValue) != "" {
 		packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, c.ControlValue, "Control Value"))
 	}
 	return packet

--- a/control.go
+++ b/control.go
@@ -39,7 +39,9 @@ func (c *ControlString) Encode() *ber.Packet {
 	if c.Criticality {
 		packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Criticality, "Criticality"))
 	}
-	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, c.ControlValue, "Control Value"))
+	if string.TrimSpace(c.ControlValue) != "" {
+		packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, c.ControlValue, "Control Value"))
+	}
 	return packet
 }
 


### PR DESCRIPTION
When ManageDSAit control was sent, the Control Value are expected to be empty. 
Instead what happen previously,  a whitespace was sent as a result of the encoding process. This causes the backend ldap to complain and returns an error.
This change ensures that no whitespace are sent in the control value.
