### PR TITLE
make serve function public

### DIFF
--- a/modify.go
+++ b/modify.go
@@ -49,15 +49,15 @@ var LDAPModifyAttributeMap = map[uint64]string{
 }
 
 type PartialAttribute struct {
-	attrType string
-	attrVals []string
+	AttrType string
+	AttrVals []string
 }
 
 func (p *PartialAttribute) encode() *ber.Packet {
 	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "PartialAttribute")
-	seq.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, p.attrType, "Type"))
+	seq.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, p.AttrType, "Type"))
 	set := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSet, nil, "AttributeValue")
-	for _, value := range p.attrVals {
+	for _, value := range p.AttrVals {
 		set.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, value, "Vals"))
 	}
 	seq.AppendChild(set)
@@ -66,40 +66,40 @@ func (p *PartialAttribute) encode() *ber.Packet {
 
 type ModifyRequest struct {
 	Dn                string
-	addAttributes     []PartialAttribute
-	deleteAttributes  []PartialAttribute
-	replaceAttributes []PartialAttribute
+	AddAttributes     []PartialAttribute
+	DeleteAttributes  []PartialAttribute
+	ReplaceAttributes []PartialAttribute
 }
 
 func (m *ModifyRequest) Add(attrType string, attrVals []string) {
-	m.addAttributes = append(m.addAttributes, PartialAttribute{attrType: attrType, attrVals: attrVals})
+	m.AddAttributes = append(m.AddAttributes, PartialAttribute{AttrType: attrType, AttrVals: attrVals})
 }
 
 func (m *ModifyRequest) Delete(attrType string, attrVals []string) {
-	m.deleteAttributes = append(m.deleteAttributes, PartialAttribute{attrType: attrType, attrVals: attrVals})
+	m.DeleteAttributes = append(m.DeleteAttributes, PartialAttribute{AttrType: attrType, AttrVals: attrVals})
 }
 
 func (m *ModifyRequest) Replace(attrType string, attrVals []string) {
-	m.replaceAttributes = append(m.replaceAttributes, PartialAttribute{attrType: attrType, attrVals: attrVals})
+	m.ReplaceAttributes = append(m.ReplaceAttributes, PartialAttribute{AttrType: attrType, AttrVals: attrVals})
 }
 
 func (m ModifyRequest) encode() *ber.Packet {
 	request := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationModifyRequest, nil, "Modify Request")
 	request.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, m.Dn, "DN"))
 	changes := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Changes")
-	for _, attribute := range m.addAttributes {
+	for _, attribute := range m.AddAttributes {
 		change := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Change")
 		change.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, uint64(AddAttribute), "Operation"))
 		change.AppendChild(attribute.encode())
 		changes.AppendChild(change)
 	}
-	for _, attribute := range m.deleteAttributes {
+	for _, attribute := range m.DeleteAttributes {
 		change := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Change")
 		change.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, uint64(DeleteAttribute), "Operation"))
 		change.AppendChild(attribute.encode())
 		changes.AppendChild(change)
 	}
-	for _, attribute := range m.replaceAttributes {
+	for _, attribute := range m.ReplaceAttributes {
 		change := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Change")
 		change.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, uint64(ReplaceAttribute), "Operation"))
 		change.AppendChild(attribute.encode())

--- a/modify.go
+++ b/modify.go
@@ -65,7 +65,7 @@ func (p *PartialAttribute) encode() *ber.Packet {
 }
 
 type ModifyRequest struct {
-	dn                string
+	Dn                string
 	addAttributes     []PartialAttribute
 	deleteAttributes  []PartialAttribute
 	replaceAttributes []PartialAttribute
@@ -85,7 +85,7 @@ func (m *ModifyRequest) Replace(attrType string, attrVals []string) {
 
 func (m ModifyRequest) encode() *ber.Packet {
 	request := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationModifyRequest, nil, "Modify Request")
-	request.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, m.dn, "DN"))
+	request.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, m.Dn, "DN"))
 	changes := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Changes")
 	for _, attribute := range m.addAttributes {
 		change := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Change")
@@ -113,7 +113,7 @@ func NewModifyRequest(
 	dn string,
 ) *ModifyRequest {
 	return &ModifyRequest{
-		dn: dn,
+		Dn: dn,
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -2,12 +2,13 @@ package ldap
 
 import (
 	"crypto/tls"
-	"github.com/nmcclain/asn1-ber"
 	"io"
 	"log"
 	"net"
 	"strings"
 	"sync"
+
+	"github.com/nmcclain/asn1-ber"
 )
 
 type Binder interface {
@@ -156,7 +157,7 @@ func (server *Server) ListenAndServeTLS(listenString string, certFile string, ke
 	if err != nil {
 		return err
 	}
-	err = server.serve(ln)
+	err = server.Serve(ln)
 	if err != nil {
 		return err
 	}
@@ -184,14 +185,14 @@ func (server *Server) ListenAndServe(listenString string) error {
 	if err != nil {
 		return err
 	}
-	err = server.serve(ln)
+	err = server.Serve(ln)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (server *Server) serve(ln net.Listener) error {
+func (server *Server) Serve(ln net.Listener) error {
 	newConn := make(chan net.Conn)
 	go func() {
 		for {

--- a/server_modify.go
+++ b/server_modify.go
@@ -1,9 +1,10 @@
 package ldap
 
 import (
-	"github.com/nmcclain/asn1-ber"
 	"log"
 	"net"
+
+	"github.com/nmcclain/asn1-ber"
 )
 
 func HandleAddRequest(req *ber.Packet, boundDN string, fns map[string]Adder, conn net.Conn) (resultCode LDAPResultCode) {
@@ -84,7 +85,7 @@ func HandleModifyRequest(req *ber.Packet, boundDN string, fns map[string]Modifie
 		if len(attrs) != 2 {
 			return LDAPResultProtocolError
 		}
-		attr.attrType, ok = attrs[0].Value.(string)
+		attr.AttrType, ok = attrs[0].Value.(string)
 		if !ok {
 			return LDAPResultProtocolError
 		}
@@ -93,7 +94,7 @@ func HandleModifyRequest(req *ber.Packet, boundDN string, fns map[string]Modifie
 			if !ok {
 				return LDAPResultProtocolError
 			}
-			attr.attrVals = append(attr.attrVals, v)
+			attr.AttrVals = append(attr.AttrVals, v)
 		}
 		op, ok := change.Children[0].Value.(uint64)
 		if !ok {
@@ -104,11 +105,11 @@ func HandleModifyRequest(req *ber.Packet, boundDN string, fns map[string]Modifie
 			log.Printf("Unrecognized Modify attribute %d", op)
 			return LDAPResultProtocolError
 		case AddAttribute:
-			modReq.Add(attr.attrType, attr.attrVals)
+			modReq.Add(attr.AttrType, attr.AttrVals)
 		case DeleteAttribute:
-			modReq.Delete(attr.attrType, attr.attrVals)
+			modReq.Delete(attr.AttrType, attr.AttrVals)
 		case ReplaceAttribute:
-			modReq.Replace(attr.attrType, attr.attrVals)
+			modReq.Replace(attr.AttrType, attr.AttrVals)
 		}
 	}
 	fnNames := []string{}

--- a/server_modify.go
+++ b/server_modify.go
@@ -71,7 +71,7 @@ func HandleModifyRequest(req *ber.Packet, boundDN string, fns map[string]Modifie
 	}
 	var ok bool
 	modReq := ModifyRequest{}
-	modReq.dn, ok = req.Children[0].Value.(string)
+	modReq.Dn, ok = req.Children[0].Value.(string)
 	if !ok {
 		return LDAPResultProtocolError
 	}

--- a/server_modify_test.go
+++ b/server_modify_test.go
@@ -179,7 +179,7 @@ func (h modifyTestHandler) Delete(boundDN, deleteDN string, conn net.Conn) (LDAP
 }
 func (h modifyTestHandler) Modify(boundDN string, req ModifyRequest, conn net.Conn) (LDAPResultCode, error) {
 	// only succeed on expected contents of modify.ldif:
-	if req.dn == "cn=testy,dc=example,dc=com" && len(req.addAttributes) == 1 &&
+	if req.Dn == "cn=testy,dc=example,dc=com" && len(req.addAttributes) == 1 &&
 		len(req.deleteAttributes) == 3 && len(req.replaceAttributes) == 2 &&
 		req.deleteAttributes[2].attrType == "details" && len(req.deleteAttributes[2].attrVals) == 0 {
 		return LDAPResultSuccess, nil

--- a/server_modify_test.go
+++ b/server_modify_test.go
@@ -179,9 +179,9 @@ func (h modifyTestHandler) Delete(boundDN, deleteDN string, conn net.Conn) (LDAP
 }
 func (h modifyTestHandler) Modify(boundDN string, req ModifyRequest, conn net.Conn) (LDAPResultCode, error) {
 	// only succeed on expected contents of modify.ldif:
-	if req.Dn == "cn=testy,dc=example,dc=com" && len(req.addAttributes) == 1 &&
-		len(req.deleteAttributes) == 3 && len(req.replaceAttributes) == 2 &&
-		req.deleteAttributes[2].attrType == "details" && len(req.deleteAttributes[2].attrVals) == 0 {
+	if req.Dn == "cn=testy,dc=example,dc=com" && len(req.AddAttributes) == 1 &&
+		len(req.DeleteAttributes) == 3 && len(req.ReplaceAttributes) == 2 &&
+		req.DeleteAttributes[2].AttrType == "details" && len(req.DeleteAttributes[2].AttrVals) == 0 {
 		return LDAPResultSuccess, nil
 	}
 	return LDAPResultInsufficientAccessRights, nil

--- a/server_search_test.go
+++ b/server_search_test.go
@@ -281,7 +281,7 @@ func TestSearchFiltering(t *testing.T) {
 				"-b", serverBaseDN, "-D", "cn=testy,"+serverBaseDN, "-w", "iLike2test", i.filterStr)
 			out, _ := cmd.CombinedOutput()
 			if !strings.Contains(string(out), "numResponses: "+i.numResponses) {
-				t.Errorf("ldapsearch failed - expected numResponses==%d: %v", i.numResponses, string(out))
+				t.Errorf("ldapsearch failed - expected numResponses==%s: %v", i.numResponses, string(out))
 			}
 			done <- true
 		}()


### PR DESCRIPTION
in line with `http.Serve` I would like to make the `ldap.server.Serve` public.

This allow us to write the ListenAndServe function in such a way that the tcp socket is opened when returning from  the function, and hence simplifying writing test-cases.