### PR TITLE
Fixed handling of UTF8 chars in filter value

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -7,8 +7,10 @@ package ldap
 import (
 	"errors"
 	"fmt"
-	"github.com/nmcclain/asn1-ber"
 	"strings"
+	"unicode/utf8"
+
+	ber "github.com/nmcclain/asn1-ber"
 )
 
 const (
@@ -179,10 +181,13 @@ func compileFilter(filter string, pos int) (*ber.Packet, int, error) {
 	default:
 		attribute := ""
 		condition := ""
-		for newPos < len(filter) && filter[newPos] != ')' {
+
+		for w := 0; newPos < len(filter) && filter[newPos] != ')'; newPos += w {
+			rune, width := utf8.DecodeRuneInString(filter[newPos:])
+			w = width
 			switch {
 			case packet != nil:
-				condition += fmt.Sprintf("%c", filter[newPos])
+				condition += fmt.Sprintf("%c", rune)
 			case filter[newPos] == '=':
 				packet = ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterEqualityMatch, nil, FilterMap[FilterEqualityMatch])
 			case filter[newPos] == '>' && filter[newPos+1] == '=':
@@ -197,7 +202,6 @@ func compileFilter(filter string, pos int) (*ber.Packet, int, error) {
 			case packet == nil:
 				attribute += fmt.Sprintf("%c", filter[newPos])
 			}
-			newPos++
 		}
 		if newPos == len(filter) {
 			err = NewError(ErrorFilterCompile, errors.New("ldap: unexpected end of filter"))

--- a/filter_test.go
+++ b/filter_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/nmcclain/asn1-ber"
+	ber "github.com/nmcclain/asn1-ber"
 )
 
 type compileTest struct {
@@ -13,18 +13,18 @@ type compileTest struct {
 }
 
 var testFilters = []compileTest{
-	compileTest{filterStr: "(&(sn=Miller)(givenName=Bob))", filterType: FilterAnd},
-	compileTest{filterStr: "(|(sn=Miller)(givenName=Bob))", filterType: FilterOr},
-	compileTest{filterStr: "(!(sn=Miller))", filterType: FilterNot},
-	compileTest{filterStr: "(sn=Miller)", filterType: FilterEqualityMatch},
-	compileTest{filterStr: "(sn=Mill*)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn=*Mill)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn=*Mill*)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn>=Miller)", filterType: FilterGreaterOrEqual},
-	compileTest{filterStr: "(sn<=Miller)", filterType: FilterLessOrEqual},
-	compileTest{filterStr: "(sn=*)", filterType: FilterPresent},
-	compileTest{filterStr: "(sn~=Miller)", filterType: FilterApproxMatch},
-	// compileTest{ filterStr: "()", filterType: FilterExtensibleMatch },
+	{filterStr: "(&(sn=Müller)(givenName=Bob))", filterType: FilterAnd},
+	{filterStr: "(|(sn=Möller)(givenName=Bob))", filterType: FilterOr},
+	{filterStr: "(!(sn=Møller))", filterType: FilterNot},
+	{filterStr: "(sn=Müller)", filterType: FilterEqualityMatch},
+	{filterStr: "(sn=Möll*)", filterType: FilterSubstrings},
+	{filterStr: "(sn=*Møll)", filterType: FilterSubstrings},
+	{filterStr: "(sn=*Müll*)", filterType: FilterSubstrings},
+	{filterStr: "(sn>=Möller)", filterType: FilterGreaterOrEqual},
+	{filterStr: "(sn<=Møller)", filterType: FilterLessOrEqual},
+	{filterStr: "(sn=*)", filterType: FilterPresent},
+	{filterStr: "(sn~=Müller)", filterType: FilterApproxMatch},
+	// { filterStr: "()", filterType: FilterExtensibleMatch },
 }
 
 func TestFilter(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/nmcclain/ldap
+
+go 1.14
+
+require github.com/nmcclain/asn1-ber v0.0.0-20170104154839-2661553a0484

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/nmcclain/asn1-ber v0.0.0-20170104154839-2661553a0484 h1:D9EvfGQvlkKaDr2CRKN++7HbSXbefUNDrPq60T+g24s=
+github.com/nmcclain/asn1-ber v0.0.0-20170104154839-2661553a0484/go.mod h1:O1EljZ+oHprtxDDPHiMWVo/5dBT6PlvWX5PSwj80aBA=


### PR DESCRIPTION
filer.compileFilter() struggled on UTF-8 chars within the search string like (something=Müller).

How's this fix?