### PR TITLE
Add Context to requests

### DIFF
--- a/ldap.go
+++ b/ldap.go
@@ -165,6 +165,7 @@ type Attribute struct {
 type AddRequest struct {
 	dn         string
 	attributes []Attribute
+	Context    context.Context
 }
 type DeleteRequest struct {
 	dn string
@@ -174,14 +175,16 @@ type ModifyDNRequest struct {
 	newrdn       string
 	deleteoldrdn bool
 	newSuperior  string
+	Context      context.Context
 }
 type AttributeValueAssertion struct {
 	attributeDesc  string
 	assertionValue string
 }
 type CompareRequest struct {
-	dn  string
-	ava []AttributeValueAssertion
+	dn      string
+	ava     []AttributeValueAssertion
+	Context context.Context
 }
 type ExtendedRequest struct {
 	requestName  string

--- a/ldap.go
+++ b/ldap.go
@@ -5,6 +5,7 @@
 package ldap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -185,6 +186,7 @@ type CompareRequest struct {
 type ExtendedRequest struct {
 	requestName  string
 	requestValue string
+	Context      context.Context
 }
 
 // Adds descriptions to an LDAP Response packet for debugging

--- a/modify.go
+++ b/modify.go
@@ -30,6 +30,7 @@
 package ldap
 
 import (
+	"context"
 	"errors"
 	"log"
 
@@ -69,6 +70,7 @@ type ModifyRequest struct {
 	AddAttributes     []PartialAttribute
 	DeleteAttributes  []PartialAttribute
 	ReplaceAttributes []PartialAttribute
+	Context           context.Context
 }
 
 func (m *ModifyRequest) Add(attrType string, attrVals []string) {

--- a/search.go
+++ b/search.go
@@ -60,6 +60,7 @@
 package ldap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -170,6 +171,7 @@ type SearchRequest struct {
 	Filter       string
 	Attributes   []string
 	Controls     []Control
+	Context      context.Context
 }
 
 func (s *SearchRequest) encode() (*ber.Packet, error) {

--- a/server.go
+++ b/server.go
@@ -25,7 +25,7 @@ type Modifier interface {
 	Modify(boundDN string, req ModifyRequest, conn net.Conn) (LDAPResultCode, error)
 }
 type Deleter interface {
-	Delete(boundDN, deleteDN string, conn net.Conn) (LDAPResultCode, error)
+	Delete(boundDN, deleteDN string, conn net.Conn, ctx context.Context) (LDAPResultCode, error)
 }
 type ModifyDNr interface {
 	ModifyDN(boundDN string, req ModifyDNRequest, conn net.Conn) (LDAPResultCode, error)
@@ -321,35 +321,35 @@ handler:
 			break handler
 
 		case ApplicationAddRequest:
-			ldapResultCode := HandleAddRequest(req, boundDN, server.AddFns, conn)
+			ldapResultCode := HandleAddRequest(req, boundDN, server.AddFns, conn, ctx)
 			responsePacket := encodeLDAPResponse(messageID, ApplicationAddResponse, ldapResultCode, LDAPResultCodeMap[ldapResultCode])
 			if err = sendPacket(conn, responsePacket); err != nil {
 				log.Printf("sendPacket error %s", err.Error())
 				break handler
 			}
 		case ApplicationModifyRequest:
-			ldapResultCode := HandleModifyRequest(req, boundDN, server.ModifyFns, conn)
+			ldapResultCode := HandleModifyRequest(req, boundDN, server.ModifyFns, conn, ctx)
 			responsePacket := encodeLDAPResponse(messageID, ApplicationModifyResponse, ldapResultCode, LDAPResultCodeMap[ldapResultCode])
 			if err = sendPacket(conn, responsePacket); err != nil {
 				log.Printf("sendPacket error %s", err.Error())
 				break handler
 			}
 		case ApplicationDelRequest:
-			ldapResultCode := HandleDeleteRequest(req, boundDN, server.DeleteFns, conn)
+			ldapResultCode := HandleDeleteRequest(req, boundDN, server.DeleteFns, conn, ctx)
 			responsePacket := encodeLDAPResponse(messageID, ApplicationDelResponse, ldapResultCode, LDAPResultCodeMap[ldapResultCode])
 			if err = sendPacket(conn, responsePacket); err != nil {
 				log.Printf("sendPacket error %s", err.Error())
 				break handler
 			}
 		case ApplicationModifyDNRequest:
-			ldapResultCode := HandleModifyDNRequest(req, boundDN, server.ModifyDNFns, conn)
+			ldapResultCode := HandleModifyDNRequest(req, boundDN, server.ModifyDNFns, conn, ctx)
 			responsePacket := encodeLDAPResponse(messageID, ApplicationModifyDNResponse, ldapResultCode, LDAPResultCodeMap[ldapResultCode])
 			if err = sendPacket(conn, responsePacket); err != nil {
 				log.Printf("sendPacket error %s", err.Error())
 				break handler
 			}
 		case ApplicationCompareRequest:
-			ldapResultCode := HandleCompareRequest(req, boundDN, server.CompareFns, conn)
+			ldapResultCode := HandleCompareRequest(req, boundDN, server.CompareFns, conn, ctx)
 			responsePacket := encodeLDAPResponse(messageID, ApplicationCompareResponse, ldapResultCode, LDAPResultCodeMap[ldapResultCode])
 			if err = sendPacket(conn, responsePacket); err != nil {
 				log.Printf("sendPacket error %s", err.Error())
@@ -420,7 +420,7 @@ func (h defaultHandler) Add(boundDN string, req AddRequest, conn net.Conn) (LDAP
 func (h defaultHandler) Modify(boundDN string, req ModifyRequest, conn net.Conn) (LDAPResultCode, error) {
 	return LDAPResultInsufficientAccessRights, nil
 }
-func (h defaultHandler) Delete(boundDN, deleteDN string, conn net.Conn) (LDAPResultCode, error) {
+func (h defaultHandler) Delete(boundDN, deleteDN string, conn net.Conn, ctx context.Context) (LDAPResultCode, error) {
 	return LDAPResultInsufficientAccessRights, nil
 }
 func (h defaultHandler) ModifyDN(boundDN string, req ModifyDNRequest, conn net.Conn) (LDAPResultCode, error) {

--- a/server.go
+++ b/server.go
@@ -225,7 +225,7 @@ listener:
 //
 func (server *Server) handleConnection(conn net.Conn) {
 	boundDN := "" // "" == anonymous
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 handler:
 	for {
@@ -361,6 +361,8 @@ handler:
 	for _, c := range server.CloseFns {
 		c.Close(boundDN, conn)
 	}
+
+	cancel()
 
 	conn.Close()
 }

--- a/server_bind.go
+++ b/server_bind.go
@@ -2,11 +2,12 @@ package ldap
 
 import (
 	"github.com/nmcclain/asn1-ber"
+	"context"
 	"log"
 	"net"
 )
 
-func HandleBindRequest(req *ber.Packet, fns map[string]Binder, conn net.Conn) (resultCode LDAPResultCode) {
+func HandleBindRequest(req *ber.Packet, ctx context.Context, fns map[string]Binder, conn net.Conn) (resultCode LDAPResultCode) {
 	defer func() {
 		if r := recover(); r != nil {
 			resultCode = LDAPResultOperationsError
@@ -40,7 +41,7 @@ func HandleBindRequest(req *ber.Packet, fns map[string]Binder, conn net.Conn) (r
 				fnNames = append(fnNames, k)
 			}
 			fn := routeFunc(bindDN, fnNames)
-			resultCode, err := fns[fn].Bind(bindDN, bindAuth.Data.String(), conn)
+			resultCode, err := fns[fn].Bind(bindDN, bindAuth.Data.String(), conn, ctx)
 			if err != nil {
 				log.Printf("BindFn Error %s", err.Error())
 				return LDAPResultOperationsError

--- a/server_modify.go
+++ b/server_modify.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"context"
 	"log"
 	"net"
 
@@ -161,7 +162,7 @@ func HandleCompareRequest(req *ber.Packet, boundDN string, fns map[string]Compar
 	return resultCode
 }
 
-func HandleExtendedRequest(req *ber.Packet, boundDN string, fns map[string]Extender, conn net.Conn) (resultCode LDAPResultCode) {
+func HandleExtendedRequest(req *ber.Packet, boundDN string, fns map[string]Extender, conn net.Conn, ctx context.Context) (resultCode LDAPResultCode) {
 	if len(req.Children) != 1 && len(req.Children) != 2 {
 		return LDAPResultProtocolError
 	}
@@ -170,7 +171,7 @@ func HandleExtendedRequest(req *ber.Packet, boundDN string, fns map[string]Exten
 	if len(req.Children) == 2 {
 		val = ber.DecodeString(req.Children[1].Data.Bytes())
 	}
-	extReq := ExtendedRequest{name, val}
+	extReq := ExtendedRequest{name, val, ctx}
 	fnNames := []string{}
 	for k := range fns {
 		fnNames = append(fnNames, k)

--- a/server_modify.go
+++ b/server_modify.go
@@ -8,12 +8,13 @@ import (
 	"github.com/nmcclain/asn1-ber"
 )
 
-func HandleAddRequest(req *ber.Packet, boundDN string, fns map[string]Adder, conn net.Conn) (resultCode LDAPResultCode) {
+func HandleAddRequest(req *ber.Packet, boundDN string, fns map[string]Adder, conn net.Conn, ctx context.Context) (resultCode LDAPResultCode) {
 	if len(req.Children) != 2 {
 		return LDAPResultProtocolError
 	}
 	var ok bool
 	addReq := AddRequest{}
+	addReq.Context = ctx
 	addReq.dn, ok = req.Children[0].Value.(string)
 	if !ok {
 		return LDAPResultProtocolError
@@ -52,14 +53,14 @@ func HandleAddRequest(req *ber.Packet, boundDN string, fns map[string]Adder, con
 	return resultCode
 }
 
-func HandleDeleteRequest(req *ber.Packet, boundDN string, fns map[string]Deleter, conn net.Conn) (resultCode LDAPResultCode) {
+func HandleDeleteRequest(req *ber.Packet, boundDN string, fns map[string]Deleter, conn net.Conn, ctx context.Context) (resultCode LDAPResultCode) {
 	deleteDN := ber.DecodeString(req.Data.Bytes())
 	fnNames := []string{}
 	for k := range fns {
 		fnNames = append(fnNames, k)
 	}
 	fn := routeFunc(boundDN, fnNames)
-	resultCode, err := fns[fn].Delete(boundDN, deleteDN, conn)
+	resultCode, err := fns[fn].Delete(boundDN, deleteDN, conn, ctx)
 	if err != nil {
 		log.Printf("DeleteFn Error %s", err.Error())
 		return LDAPResultOperationsError
@@ -67,12 +68,13 @@ func HandleDeleteRequest(req *ber.Packet, boundDN string, fns map[string]Deleter
 	return resultCode
 }
 
-func HandleModifyRequest(req *ber.Packet, boundDN string, fns map[string]Modifier, conn net.Conn) (resultCode LDAPResultCode) {
+func HandleModifyRequest(req *ber.Packet, boundDN string, fns map[string]Modifier, conn net.Conn, ctx context.Context) (resultCode LDAPResultCode) {
 	if len(req.Children) != 2 {
 		return LDAPResultProtocolError
 	}
 	var ok bool
 	modReq := ModifyRequest{}
+	modReq.Context = ctx
 	modReq.Dn, ok = req.Children[0].Value.(string)
 	if !ok {
 		return LDAPResultProtocolError
@@ -126,12 +128,13 @@ func HandleModifyRequest(req *ber.Packet, boundDN string, fns map[string]Modifie
 	return resultCode
 }
 
-func HandleCompareRequest(req *ber.Packet, boundDN string, fns map[string]Comparer, conn net.Conn) (resultCode LDAPResultCode) {
+func HandleCompareRequest(req *ber.Packet, boundDN string, fns map[string]Comparer, conn net.Conn, ctx context.Context) (resultCode LDAPResultCode) {
 	if len(req.Children) != 2 {
 		return LDAPResultProtocolError
 	}
 	var ok bool
 	compReq := CompareRequest{}
+	compReq.Context = ctx
 	compReq.dn, ok = req.Children[0].Value.(string)
 	if !ok {
 		return LDAPResultProtocolError
@@ -195,12 +198,13 @@ func HandleAbandonRequest(req *ber.Packet, boundDN string, fns map[string]Abando
 	return err
 }
 
-func HandleModifyDNRequest(req *ber.Packet, boundDN string, fns map[string]ModifyDNr, conn net.Conn) (resultCode LDAPResultCode) {
+func HandleModifyDNRequest(req *ber.Packet, boundDN string, fns map[string]ModifyDNr, conn net.Conn, ctx context.Context) (resultCode LDAPResultCode) {
 	if len(req.Children) != 3 && len(req.Children) != 4 {
 		return LDAPResultProtocolError
 	}
 	var ok bool
 	mdnReq := ModifyDNRequest{}
+	mdnReq.Context = ctx
 	mdnReq.dn, ok = req.Children[0].Value.(string)
 	if !ok {
 		return LDAPResultProtocolError

--- a/server_modify_test.go
+++ b/server_modify_test.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"context"
 	"net"
 	"os/exec"
 	"strings"
@@ -155,7 +156,7 @@ func TestModifyDN(t *testing.T) {
 type modifyTestHandler struct {
 }
 
-func (h modifyTestHandler) Bind(bindDN, bindSimplePw string, conn net.Conn) (LDAPResultCode, error) {
+func (h modifyTestHandler) Bind(bindDN, bindSimplePw string, conn net.Conn, ctx context.Context) (LDAPResultCode, error) {
 	if bindDN == "" && bindSimplePw == "" {
 		return LDAPResultSuccess, nil
 	}

--- a/server_modify_test.go
+++ b/server_modify_test.go
@@ -171,7 +171,7 @@ func (h modifyTestHandler) Add(boundDN string, req AddRequest, conn net.Conn) (L
 	}
 	return LDAPResultInsufficientAccessRights, nil
 }
-func (h modifyTestHandler) Delete(boundDN, deleteDN string, conn net.Conn) (LDAPResultCode, error) {
+func (h modifyTestHandler) Delete(boundDN, deleteDN string, conn net.Conn, ctx context.Context) (LDAPResultCode, error) {
 	// only succeed on expected deleteDN
 	if deleteDN == "cn=Delete Me,dc=example,dc=com" {
 		return LDAPResultSuccess, nil

--- a/server_search.go
+++ b/server_search.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -9,7 +10,7 @@ import (
 	ber "github.com/nmcclain/asn1-ber"
 )
 
-func HandleSearchRequest(req *ber.Packet, controls *[]Control, messageID uint64, boundDN string, server *Server, conn net.Conn) (resultErr error) {
+func HandleSearchRequest(req *ber.Packet, controls *[]Control, messageID uint64, boundDN string, server *Server, conn net.Conn, ctx context.Context) (resultErr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			resultErr = NewError(LDAPResultOperationsError, fmt.Errorf("Search function panic: %s", r))
@@ -20,6 +21,7 @@ func HandleSearchRequest(req *ber.Packet, controls *[]Control, messageID uint64,
 	if err != nil {
 		return NewError(LDAPResultOperationsError, err)
 	}
+	searchReq.Context = ctx
 
 	filterPacket, err := CompileFilter(searchReq.Filter)
 	if err != nil {
@@ -150,7 +152,7 @@ func parseSearchRequest(boundDN string, req *ber.Packet, controls *[]Control) (S
 	}
 	searchReq := SearchRequest{baseObject, scope,
 		derefAliases, sizeLimit, timeLimit,
-		typesOnly, filter, attributes, *controls}
+		typesOnly, filter, attributes, *controls, nil}
 
 	return searchReq, nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"net"
 	"os/exec"
@@ -294,7 +295,7 @@ func TestSearchStats(t *testing.T) {
 type bindAnonOK struct {
 }
 
-func (b bindAnonOK) Bind(bindDN, bindSimplePw string, conn net.Conn) (LDAPResultCode, error) {
+func (b bindAnonOK) Bind(bindDN, bindSimplePw string, conn net.Conn, ctx context.Context) (LDAPResultCode, error) {
 	if bindDN == "" && bindSimplePw == "" {
 		return LDAPResultSuccess, nil
 	}
@@ -304,7 +305,7 @@ func (b bindAnonOK) Bind(bindDN, bindSimplePw string, conn net.Conn) (LDAPResult
 type bindSimple struct {
 }
 
-func (b bindSimple) Bind(bindDN, bindSimplePw string, conn net.Conn) (LDAPResultCode, error) {
+func (b bindSimple) Bind(bindDN, bindSimplePw string, conn net.Conn, ctx context.Context) (LDAPResultCode, error) {
 	if bindDN == "cn=testy,o=testers,c=test" && bindSimplePw == "iLike2test" {
 		return LDAPResultSuccess, nil
 	}
@@ -314,7 +315,7 @@ func (b bindSimple) Bind(bindDN, bindSimplePw string, conn net.Conn) (LDAPResult
 type bindSimple2 struct {
 }
 
-func (b bindSimple2) Bind(bindDN, bindSimplePw string, conn net.Conn) (LDAPResultCode, error) {
+func (b bindSimple2) Bind(bindDN, bindSimplePw string, conn net.Conn, ctx context.Context) (LDAPResultCode, error) {
 	if bindDN == "cn=testy,o=testers,c=testz" && bindSimplePw == "ZLike2test" {
 		return LDAPResultSuccess, nil
 	}
@@ -324,7 +325,7 @@ func (b bindSimple2) Bind(bindDN, bindSimplePw string, conn net.Conn) (LDAPResul
 type bindPanic struct {
 }
 
-func (b bindPanic) Bind(bindDN, bindSimplePw string, conn net.Conn) (LDAPResultCode, error) {
+func (b bindPanic) Bind(bindDN, bindSimplePw string, conn net.Conn, ctx context.Context) (LDAPResultCode, error) {
 	panic("test panic at the disco")
 	return LDAPResultInvalidCredentials, nil
 }


### PR DESCRIPTION
Since LDAP sends multiple requests over the same connection, it can be helpful to have a single context per TCP Connection.

This allows the following things:

- Store data in the context, e.g. a user object after bind, which can then be checked on search
- Pass the context to subsequent API calls to cancel them when the TCP connection is dropped