### PR TITLE
listen on a custom network (ex. unix socket)

### DIFF
--- a/server.go
+++ b/server.go
@@ -180,8 +180,12 @@ func (server *Server) GetStats() Stats {
 	return *server.Stats
 }
 
-func (server *Server) ListenAndServe(listenString string) error {
-	ln, err := net.Listen("tcp", listenString)
+func (server *Server) ListenAndServe(listenString string, args ...string) error {
+	network := "tcp"
+	if (len(args) > 0) {
+		network = args[0]
+	}
+	ln, err := net.Listen(network, listenString)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch modifies `ListenAndServe` and adds a second optional argument that allows to listen on a custom network. Network is a string, as specified by https://pkg.go.dev/net#Listen

This allows listening on a UNIX socket, as listening on a non-privileged TCP can be insecure.